### PR TITLE
PROPOSAL: Add Verifier DID to VP Generation API

### DIFF
--- a/digital-wallet-specification.json
+++ b/digital-wallet-specification.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "Digital Wallet Provider OpenAPI Specification",
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "paths": {
     "/api/v1/verifiablePresentation/verify": {

--- a/digital-wallet-specification.json
+++ b/digital-wallet-specification.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "Digital Wallet Provider OpenAPI Specification",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "paths": {
     "/api/v1/verifiablePresentation/verify": {
@@ -22,7 +22,8 @@
                 "$ref": "#/components/schemas/Request_VerifiablePresentation_Verify"
               },
               "example": {
-                "verifiablePresentation": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRpZDpleGFtcGxlOjB [...]"
+                "verifiablePresentation": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRpZDpleGFtcGxlOjB [...]",
+                "verifierDID": "did:ethr:example"
               }
             }
           }
@@ -240,13 +241,18 @@
       "Request_VerifiablePresentation_Verify": {
         "type": "object",
         "required": [
-          "verifablePresentation"
+          "verifablePresentation",
+          "verifierDID"
         ],
         "properties": {
           "verifablePresentation": {
             "description": "The verifiable presentation to verify in JWT Base64 encoded format",
             "type": "string",
             "format": "base64"
+          },
+          "verifierDID": {
+            "description": "The DID that requests a verification of the attached Verifiable Presentation.",
+            "type": "string"
           }
         }
       },


### PR DESCRIPTION
## General
This pull request proposes to add a **required** `verifierDID` value to the VP verification request body in the [Digital Wallet Conformance Criteria](https://open-credentialing-initiative.github.io/Digital-Wallet-Conformance-Criteria). 

## Reasoning
As I see it as of today, OCI is aiming to define architecture-agnostic specifications that gives developers freedom regarding their specific implementations as long as they adhere to the defined specifications. This approach seems to be broken regarding the VP verification API in the [Digital Wallet Conformance Criteria](https://open-credentialing-initiative.github.io/Digital-Wallet-Conformance-Criteria/#api-to-verify-verifiable-presentation-of-atp-credential).

This is very much apparent if the implementation supports holding multiple DIDs over maybe multiple different tenants within a solution. With the current specification, it is not possible to define which entity/ DID requested a VP verification, which may lead to further problematic limitations. Those may include, e.g., not being able to save the result of a VP verification process to the verifying parties tenant/ agent, which may be needed for regulatory purposes (see audit trail).

Interestingly, this approach of adding a DID to the request body is already embraced looking at the VP generation API which allows the correct addressing of which DID (`holderDID`), and therefore maybe which tenant, should generate a VP of the specified credential type. (see [Digital Wallet Conformance VP generation API request body](https://open-credentialing-initiative.github.io/Digital-Wallet-Conformance-Criteria/#api-to-generate-a-verifiable-presentation-of-atp-credential)) 

## Impact

Because the proposed addition of the `verifierDID` being **required**, all existing implementations would need to consider the new value in the request body. If not needed, it can be ignored. Not implementing the specified `verifierDID` will result in other parties not being able to, e.g., maintain their audit trail for VP verification events.

<hl>

This PR is connected to another [PR on the Digital Wallet Conformance Criteria](https://github.com/Open-Credentialing-Initiative/Digital-Wallet-Conformance-Criteria/pulls)